### PR TITLE
ENABLE-314 switch to prisma-cloud-scan

### DIFF
--- a/.github/workflows/docker-linting.yml
+++ b/.github/workflows/docker-linting.yml
@@ -4,10 +4,8 @@ name: 'DockerLinting'
 on:  # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
-      aws_ecr_account:
+      aws_account_id:
         type: 'string'
-        # One of 'DT', 'WE', 'CR', or ??'Iridium'??
-        default: 'Iridium'
         required: true
       dockerfile_folder:
         type: 'string'
@@ -21,10 +19,7 @@ on:  # yamllint disable-line rule:truthy
         type: 'string'
         default: 'main'
         required: false
-      ecr_path:
-        type: 'string'
-        required: true
-      docker_image_name:
+      ecr_registry:
         type: 'string'
         required: true
       docker_image_tag:
@@ -36,6 +31,12 @@ on:  # yamllint disable-line rule:truthy
       twistlock_key_id:
         required: true
       twistlock_key:
+        required: true
+      aws_region:
+        required: true
+      aws_access_key_id:
+        required: true
+      aws_access_key:
         required: true
 
 jobs:
@@ -49,7 +50,7 @@ jobs:
         uses: 'actions/checkout@v2'
         with:
           repository: 'novu/github-actions'
-          token: '${{ secrets.NOVU_CI_TOKEN }}'
+          token: '${{ secrets.ci_token }}'
           path: '.github-actions'
           ref: '${{ inputs.action_ref }}'
 
@@ -67,77 +68,22 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@v2'
 
-      - name: 'Configure DT AWS credentials'
-        if: "${{ inputs.aws_ecr_account }} == 'DT'"
+      - name: 'Configure AWS credentials'
         uses: 'aws-actions/configure-aws-credentials@v1'
         with:
-          aws-access-key-id: '${{ secrets.DT_TEST_ACCESS_KEY }}'
-          aws-secret-access-key: '${{ secrets.DT_TEST_SECRET_KEY }}'
-          aws-region: '${{ secrets.DT_TEST_AWS_REGION }}'
-
-      - name: 'Configure CR AWS credentials'
-        if: "${{ inputs.aws_ecr_account }} == 'CR'"
-        uses: 'aws-actions/configure-aws-credentials@v1'
-        with:
-          aws-access-key-id: '${{ secrets.CR_TEST_ACCESS_KEY }}'
-          aws-secret-access-key: '${{ secrets.CR_TEST_SECRET_KEY }}'
-          aws-region: '${{ secrets.CR_TEST_AWS_REGION }}'
-
-      - name: 'Configure WE AWS Credentials'
-        if: "${{ inputs.aws_ecr_account }} == 'WE'"
-        uses: 'aws-actions/configure-aws-credentials@v1'
-        with:
-          aws-access-key-id: '${{ secrets.AWS_ACCESS_KEY_ID }}'
-          aws-secret-access-key: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
-          aws-region: '${{ secrets.AWS_REGION }}'
+          aws-access-key-id: '${{ secrets.aws_access_key_id }}'
+          aws-secret-access-key: '${{ secrets.aws_access_key }}'
+          aws-region: '${{ secrets.aws_region }}'
 
       - name: 'Login to Amazon ECR'
         id: 'login-ecr'
         uses: 'aws-actions/amazon-ecr-login@v1'
 
-      - name: 'Download TwistCli'
-        run: |
-          TWIST_URL="https://us-east1.cloud.twistlock.com/us-1-111575341/api/v1/util/twistcli"
-          curl -k -u ${{ secrets.TWISTLOCK_KEY_ID }}:${{ secrets.TWISTLOCK_KEY }} --output ./twistcli "$TWIST_URL"
-          sudo chmod a+x ./twistcli
-
-      - name: 'Pull DT Docker Image'
-        if: "${{ inputs.aws_ecr_account }} == 'DT'"
-        env:
-          ACCOUNT_ID: '304489958799'
-          ECR_PATH: '${{ inputs.ecr_path }}'
-          IMG_NAME: '${{ inputs.docker_image_name }}'
-          IMG_TAG: '${{ inputs.docker_image_tag }}'
-        run: |
-          docker pull "${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/${ECR_PATH}/${IMG_NAME}:${IMG_TAG}"
-
-      - name: 'Pull CR Docker Image'
-        if: "${{ inputs.aws_ecr_account }} == 'CR'"
-        env:
-          ACCOUNT_ID: '883942481425'
-          ECR_PATH: '${{ inputs.ecr_path }}'
-          IMG_NAME: '${{ inputs.docker_image_name }}'
-          IMG_TAG: '${{ inputs.docker_image_tag }}'
-        run: |
-          docker pull "${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/${ECR_PATH}/${IMG_NAME}:${IMG_TAG}"
-
-      - name: 'Pull WE Docker Image'
-        if: "${{ inputs.aws_ecr_account }} == 'WE'"
-        env:
-          ACCOUNT_ID: '822373129316'
-          ECR_PATH: '${{ inputs.ecr_path }}'
-          IMG_NAME: '${{ inputs.docker_image_name }}'
-          IMG_TAG: '${{ inputs.docker_image_tag }}'
-        run: |
-          docker pull "${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/${ECR_PATH}/${IMG_NAME}:${IMG_TAG}"
-
-      - name: 'Scan the image'
-        env:
-          IMG_NAME: '${{ inputs.docker_image_name }}'
-          IMG_TAG: '${{ inputs.docker_image_tag }}'
-        run: |
-            ./twistcli images scan \
-              --details \
-              --address https://us-east1.cloud.twistlock.com/us-1-111575341 \
-              -u ${{ secrets.twistlock_key_id }} -p ${{ secrets.twistlock_key }} \
-              ${IMG_NAME}:${IMG_TAG}
+      - name: 'Prisma Cloud image scan'
+        id: 'scan'
+        uses: 'PaloAltoNetworks/prisma-cloud-scan@v1'
+        with:
+          pcc_console_url: 'https://us-east1.cloud.twistlock.com/us-1-111575341'
+          pcc_user: '${{ secrets.twistlock_key_id }}'
+          pcc_pass: '${{ secrets.twistlock_key }}'
+          image_name: '${{ inputs.aws_account_id }}.dkr.ecr.${{ secrets.aws_region }}.amazonaws.com/${{ inputs.ecr_registry }}:${{ inputs.docker_image_tag }}'

--- a/README.md
+++ b/README.md
@@ -110,16 +110,18 @@ Hadolint operates on the Dockerfile, but twistlock operates on a complete docker
 
 Inputs & Secrets:
 
-- aws_ecr_account: One of 'DT', 'WE', 'CR', or 'Iridium' ('Iridium' not yet implemented)
 - dockerfile_folder: folder within the repository where the `Dockerfile` can be found
 - hado_ignores: list of space-separated hado rules to ignore
+- aws_account_id: the aws account id where we'll pull the ECR image from
 - action_ref: the branch of the github actions repository to clone (defaults to main)
-- ecr_path: the path to the ECR registry, example: 'novu/ci-cache`
-- docker_image_name: the name of the image. The full name of the AWS ECR registry is expected to be `$ecr_path/$docker_image_name`.
+- ecr_registry: the name of the ecr registry
 - docker_image_tag: the tag indicating a specific version/image to scan
 - ci_token: github token with permissions to clone the github-actions repository
 - twistlock_key_id: twistlock key identifier
 - twistlock_key: twistlock key/password
+- aws_access_key_id: AWS access key id used to authenticate with ECR
+- aws_access_key: AWS access key used to authenticate with ECR
+- aws_region: AWS region used to authenticate with ECR
 
 Example Use:
 
@@ -129,12 +131,14 @@ Example Use:
     uses: 'icariohealth/.github/.github/workflows/docker-linting.yml@main'
     with:
       dockerfile_folder: '.'
-      aws_ecr_account: 'WE'
-      ecr_path: 'novu/ci-cache'
-      docker_image_name: 'qaautomationci'
+      aws_account_id: '822373129316'  # WE
+      ecr_registry: 'novu/ci-cache/qaautomationci'
       docker_image_tag: '${{ env.DOCKER_IMAGE_TAG_FOR_CI_RUN }}'
     secrets:
       ci_token: '${{ secrets.NOVU_CI_TOKEN }}'
       twistlock_key_id: '${{ secrets.TWISTLOCK_KEY_ID }}'
       twistlock_key: '${{ secrets.TWISTLOCK_KEY }}'
+      aws_access_key_id: '${{ secrets.AWS_ACCESS_KEY_ID }}'
+      aws_access_key: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
+      aws_region: '${{ secrets.AWS_REGION }}'
 ```


### PR DESCRIPTION
Simplifies the docker linting by handing off some of the steps to a pre-canned action and putting slightly more onus on the caller.