### PR TITLE
[CLOUD-1665] add naming rule to tflint

### DIFF
--- a/.github/workflows/tf-linting.yml
+++ b/.github/workflows/tf-linting.yml
@@ -41,8 +41,10 @@ jobs:
         name: Setup TFLint
         with:
           tflint_version: v0.44.1
+      - name: tflint version
+        run: tflint -v
       - name: Run TFLint
-        run: tflint -f compact --recursive --enable-rule=terraform_naming_convention
+        run: tflint -f compact --recursive
 
   tfsec:
     name: 'tfsec'


### PR DESCRIPTION
looks like it works:

failing run with bad naming: https://github.com/icariohealth/tf-mod-opendj/pull/27/commits/94feacbb77fac97fdf9823bf8ee70d7676fd0135
passing run after fixing naming: https://github.com/icariohealth/tf-mod-opendj/pull/27/commits/0a244047268e179b19f18292641d2b3df750a0bc